### PR TITLE
refa card: use link for the title

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -50,7 +50,7 @@
     background-color: gray;
     border-radius: 100px;
   }
-  
+
   &:after {
     display: none;
     content: "";
@@ -177,6 +177,10 @@
 
         .posters,
         .topic-title {
+          &.visited {
+            color: var(--primary-medium);
+          }
+          color: var(--primary);
           flex-grow: 1;
           word-wrap: break-word;
           overflow: hidden;

--- a/javascripts/discourse/templates/components/discourse-kanban-card.hbs
+++ b/javascripts/discourse/templates/components/discourse-kanban-card.hbs
@@ -1,6 +1,10 @@
 <div class="card-row">
   {{topic-status topic=topic}}
-  <span class="topic-title">{{topic.title}}</span>
+  {{#if topic.visited}}
+    <a class="topic-title visited">{{topic.title}}</a>
+  {{else}}
+    <a class="topic-title">{{topic.title}}</a>
+  {{/if}}
   {{format-date topic.bumpedAt format="tiny" noTitle="true"}}
 </div>
 


### PR DESCRIPTION
Use semanticized links to replace meaningless spans; this also enables more native and third-party tools' navigation.

Also, differentiated visited and unvisited topics' colors.